### PR TITLE
ft (send group messages) Users should be able to send group messages

### DIFF
--- a/api/v2/helpers/group_helpers.py
+++ b/api/v2/helpers/group_helpers.py
@@ -76,3 +76,19 @@ class GroupHelpers:
         return jsonify({'message':'Group name updated',
                         'status': 200,
                         'data': update})
+    
+    def send_group_messages(self, group_id, data):
+        uid = get_jwt_identity()
+        exists = storage.group_exists(group_id, uid)
+        if exists:
+            send = storage.group_message(data['subject'], data['message'], group_id, uid)
+            colnames = ['message_id', 'created_on', 'subject', 'message', 'parentMessageId', 'status']
+            grp_msg = []
+            for value in send:
+                grp_msg.append(dict(zip(colnames, value)))
+            
+            return jsonify({'status': 201,
+                            'data': grp_msg,
+                            'message': 'Message delivered'})
+        return jsonify({'error':'Group doesnt exist',
+                        'status': 400})

--- a/api/v2/models/database.py
+++ b/api/v2/models/database.py
@@ -75,10 +75,12 @@ class Database:
         print("Tables created")
 
     def drop_all(self):
+        drop_groupmessages_table = "DROP TABLE group_messages cascade"
         drop_groups_table = "DROP TABLE groups cascade"
         drop_groupmembers_table = "DROP TABLE groupmembers cascade"
         drop_messages_table = "DROP TABLE messages cascade"
         drop_users_table = "DROP TABLE users cascade"
+        self.cur.execute(drop_groupmessages_table)
         self.cur.execute(drop_users_table)
         self.cur.execute(drop_groupmembers_table)
         self.cur.execute(drop_groups_table)

--- a/api/v2/routes/groups.py
+++ b/api/v2/routes/groups.py
@@ -33,9 +33,16 @@ def delete_user(group_id, uid):
     """removes a user"""
     return user_grps.delete_user(group_id, uid)
 
-@apiv2.route('/groups/<group_id>/name', methods=['PATCH'])
+@apiv2.route('/groups/<int:group_id>/name', methods=['PATCH'])
 @jwt_required
 def edit_name(group_id):
     """updates the name of the group"""
     data = request.get_json()
     return user_grps.change_name(group_id, data)
+
+@apiv2.route('/groups/<int:group_id>/messages', methods=['POST'])
+@jwt_required
+def send_grp_message(group_id):
+    """Sends a message to the group"""
+    data = request.get_json()
+    return user_grps.send_group_messages(group_id, data)

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -90,3 +90,7 @@ email_none = {
 	"from" : "Me@epctester.com" ,
 	"to" : "Joh@epictester.com"
 }
+group_message = {
+    "subject" : "d",
+	"message" : "String"
+}

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,5 +1,6 @@
 import json
 from .test_base import BaseTest
+from .mock_data import group_message
 
 class TestGroups(BaseTest):
 
@@ -109,4 +110,29 @@ class TestGroups(BaseTest):
                                  headers={'Authorization': 'Bearer ' + self.token})
         self.assertTrue(response.status_code, 200)
         self.assertIn(response.get_json()['error'], 'Can\'t change name of unavialable group')
+    
+    def test_send_group_message(self):
+        """Test to send a group message"""
+        self.app.post('api/v2/groups', content_type='application/json',
+                      data=json.dumps({"name": "Almighty"}),
+                      headers={'Authorization': 'Bearer ' + self.token})
+        response = self.app.post('api/v2/groups/1/messages', content_type='application/json',
+                      data=json.dumps(group_message),
+                      headers={'Authorization': 'Bearer ' + self.token})
+        print(response.data)
+        self.assertTrue(response.status_code, 201)
+        self.assertIn(response.get_json()['message'], 'Message delivered')
+        self.assertIn(response.get_json()['data'][0]['status'], 'sent')
+    
+    def test_send_group_message_to_null_group(self):
+        """Test to send a group message"""
+        self.app.post('api/v2/groups', content_type='application/json',
+                      data=json.dumps({"name": "Almighty"}),
+                      headers={'Authorization': 'Bearer ' + self.token})
+        response = self.app.post('api/v2/groups/5/messages', content_type='application/json',
+                      data=json.dumps(group_message),
+                      headers={'Authorization': 'Bearer ' + self.token})
+        print(response.data)
+        self.assertTrue(response.status_code, 400)
+        self.assertIn(response.get_json()['error'], 'Group doesnt exist')
         


### PR DESCRIPTION
#### Users should be able to delete a single message.

#### What does this PR do?
- Implements the user feature of sending one message to a group

#### Description of Task to be completed?
- With this function, users should be able to send one message to a group.
- write tests for this feature
- write a helper function to display a success or error message when the endpoint has been accessed
- adds a query that creates a messages table and tears it down
- write a method  to save a message to the group messages table 

#### How should this be manually tested?
- Put the link below in your Postman's URL with HTTP method POST 
https://epicmail007.herokuapp.com/api/v2/groups/group_id/messages where group_id is an integer of a group that should exist. 
- Add the message in the body part of postman in the following format
```
{
  "subject": "String"
  "message": "String" 
}
```
- You shall receive a response in the following format
```
{
    "data": [
        {
            "createdOn": datetime,
            "parentMessageId": int,
            "message_id": int,
            "message": "String",
            "status": "sent",
            "subject": "String"
        },
    ],
    "message": "Message delivered"
    "status": 201
}
```
- If the group doest exist you shall receive a message n the follwing format
```
{
    "error": "Group doesnt exist",
    "status": 400
}
```

### Relevant pivotal tracker stories
[delivers #164914145]