### PR TITLE
ft (get password reset link) Users should be able to get a password r…

### DIFF
--- a/api/v2/helpers/user_helpers.py
+++ b/api/v2/helpers/user_helpers.py
@@ -70,3 +70,17 @@ class UserHelpers:
             'status': 200,
             'data': [{'token': access_token}]
         }), 200
+
+    def reset_link(self, reset_data):
+        if signup.check_email_exists(reset_data['email']):
+            return jsonify({
+                'status': 200,
+                'data': [{
+                    'message' : 'Check your email for password reset link',
+                    'email': reset_data['email']
+                    }]
+            })
+        return jsonify({
+                'status': 400,
+                'message' : 'Invalid email'
+                }), 400

--- a/api/v2/routes/user.py
+++ b/api/v2/routes/user.py
@@ -31,3 +31,9 @@ def login_user():
     """logs in a user"""
     data = request.get_json()
     return user_helper.login_user(data)
+
+@apiv2.route('/auth/reset', endpoint='reset', methods=['POST'])
+def login_user():
+    """resets a password"""
+    data = request.get_json()
+    return user_helper.reset_link(data)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -82,4 +82,28 @@ class TestUserRoutes(BaseTest):
                                  content_type='application/json')
         self.assertIn(response.get_json()["error"], "Incorrect credentials")
         self.assertEqual(response.status_code, 400)
+    
+    def test_reset_link(self):
+        """test sending a reset link"""
+        self.app.post('/api/v2/auth/signup',
+                                 data=json.dumps(signup_data),
+                                 content_type='application/json')
+        response = self.app.post('/api/v2/auth/reset',
+                      data=json.dumps({"email":"qw@epictester.com"}),
+                      content_type='application/json')
+        print(response.data)
+        self.assertIn(response.get_json()["data"][0]["message"], "Check your email for password reset link")
+        self.assertEqual(response.status_code, 200)
+    
+    def test_reset_link_2(self):
+        """test sending a reset link when the email doesnt exist"""
+        response = self.app.post('/api/v2/auth/signup',
+                                 data=json.dumps(signup_data),
+                                 content_type='application/json')
+        response = self.app.post('/api/v2/auth/reset',
+                                 data=json.dumps({"email":"we@epictester.com"}),
+                                 content_type='application/json')
+        print(response.data)
+        self.assertIn(response.get_json()["message"], "Invalid email")
+        self.assertEqual(response.status_code, 400)
         


### PR DESCRIPTION
#### Users should be able to get a password reset link

#### What does this PR do?
- Implements the user feature of resetting a password reset link so that users can change their passwords if they have forgotten them.

#### Description of Task to be completed?
- With this function, users should be able to send one message to a group.
- write tests for this feature
- create endpoint to get an email from the user
- create a helper method to check if an email exists
- return a success message stating the email reset link has been sent
- return a message if the email doesn't exist

#### How should this be manually tested?
- Put the link below in your Postman's URL with HTTP method POST 
https://epicmail007.herokuapp.com/api/v2/auth/reset
- Add your email in the body part of postman in the following format
```
{
  "email": "valid@email.com" 
}
```
- You shall receive a response in the following format
```
{
    'data' : [ {
        'message': 'Check your email for password reset link',
        'email' : 'String'
    } ],
    'status' : 200,

}
```
- If the email doesn't exist you shall receive a message in the following format
```
{
    'error': 'Invalid email',
    'status': 400
}
```

### Relevant pivotal tracker stories
- #165070057